### PR TITLE
updating activesupport version in gemspec

### DIFF
--- a/giftrocket.gemspec
+++ b/giftrocket.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['support@giftrocket.com', 'kapil@giftrocket.com']
   spec.files         = Dir['lib/**/*.rb']
 
-  spec.add_runtime_dependency 'activesupport', '~> 3.2'
+  spec.add_runtime_dependency 'activesupport', '>= 3.2', '<=5.0'
   spec.add_runtime_dependency 'httparty', '~> 0.14.0'
 
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
I did not test with activesupport >=5.0, so I added that as an upper bound. 