### PR TITLE
[MH] Gemspec: Allow jwt >= 1.5.6

### DIFF
--- a/giftrocket.gemspec
+++ b/giftrocket.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 3.2', '<= 5.1.1'
   spec.add_runtime_dependency 'httparty', '~> 0.14.0'
-  spec.add_runtime_dependency 'jwt', '1.5.6'
+  spec.add_runtime_dependency 'jwt', '>= 1.5.6'
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mocha', '~> 1.1'


### PR DESCRIPTION
We are using `omniauth-google-oauth2` in our project which references `jwt` - there is a fix that allows for multiple `iss` values as specified here:

https://github.com/zquestz/omniauth-google-oauth2/issues/296

Can we loosen the requirements on this this gem version safely?