### PR TITLE
Bump active support version

### DIFF
--- a/giftrocket.gemspec
+++ b/giftrocket.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['support@giftrocket.com', 'kapil@giftrocket.com']
   spec.files         = Dir['lib/**/*.rb']
 
-  spec.add_runtime_dependency 'activesupport', '>= 3.2', '<= 5.1.1'
+  spec.add_runtime_dependency 'activesupport', '>= 3.2', '<= 6.0.3.1'
   spec.add_runtime_dependency 'httparty', '~> 0.14.0'
   spec.add_runtime_dependency 'jwt', '1.5.6'
 


### PR DESCRIPTION
This gem's activesupport dependency is currently incompatible with the latest activesupport version. This fixes that.